### PR TITLE
fix: Remove irrelevant ibus setup

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -12,6 +12,11 @@ cp -avf "/tmp/ctx/files"/. /
 # List of rpmfusion packages can be found here:
 # https://mirrors.rpmfusion.org/mirrorlist?path=free/fedora/updates/43/x86_64/repoview/index.html&protocol=https&redirect=1
 dnf5 -y copr enable scottames/ghostty
+
+dnf5 remove -y \
+	imsettings \
+	ibus
+
 # this installs a package from fedora repos
 dnf5 install --allowerasing -y \
 	fedora-asahi-remix-release-cosmic-atomic \


### PR DESCRIPTION
Cosmic + Wayland doesn't seem to play nicely with it and it does't seem to be needed right now.
This is the notification:
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/42e41a03-0429-495e-8434-9b2246aa744f" />

