### PR TITLE
fix(asahi): persist xhci wakeup across suspend/resume

### DIFF
--- a/build_files/build-finalize.sh
+++ b/build_files/build-finalize.sh
@@ -6,7 +6,7 @@ set -ouex pipefail
 
 systemctl disable gdm.service || true
 systemctl enable cosmic-greeter.service
-systemctl enable podman.socket brew-setup.service bt-a2dp-fix.service
+systemctl enable podman.socket brew-setup.service bt-a2dp-fix.service xhci-wakeup-enable.service
 # Disable NetworkManager wait-online (unnecessary on desktops)
 systemctl disable NetworkManager-wait-online.service
 # Skip Plymouth quit wait to reduce boot delay


### PR DESCRIPTION
- add xhci-wakeup-enable.service to force xHCI wakeup=enabled at boot
- add logged/retrying 10-xhci-wakeup sleep hook for pre/post suspend timing races
- enable xhci-wakeup-enable.service in build-finalize for image defaults

Signed-off-by: Sam DaSilva <sam.ramos.dasilva@gmail.com>
